### PR TITLE
odd end-of-line error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,3 +21,6 @@ MethodLength:
 
 Metrics/AbcSize:
   Enabled: false
+
+EndOfLine:
+  Enabled: false


### PR DESCRIPTION
odd end-of-line error

This resolves the rubocop weird end-of-line error, it's not the best
fix, but havent been able to find a way around it.
