### PR TITLE
chef-guard error fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,11 @@ Gemfile.lock
 .coverage
 .kitchen
 .kitchen.local.yml
+
+files/dynatrace-agents.jar
+files/dynatrace-analysisserver.jar
+files/dynatrace-client.jar
+files/dynatrace-collector.jar
+files/dynatrace-license.lic
+files/dynatrace-server.jar
+files/dynatrace-wsagent.tar

--- a/files/.gitignore
+++ b/files/.gitignore
@@ -1,7 +1,0 @@
-dynatrace-agents.jar
-dynatrace-analysisserver.jar
-dynatrace-client.jar
-dynatrace-collector.jar
-dynatrace-license.lic
-dynatrace-server.jar
-dynatrace-wsagent.tar

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'martin.etmajer@dynatrace.com'
 license 'MIT'
 description 'Installs the Dynatrace Application Monitoring solution.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.0.5'
+version '1.0.7'
 source_url 'https://github.com/Dynatrace/Dynatrace-Chef'
 issues_url 'https://github.com/Dynatrace/Dynatrace-Chef/issues'
 


### PR DESCRIPTION
Because of double .gitignores we ran into problems utilising chef-guard.

worked them into one and bumped to version 1.0.7, skipping 1.0.6 because the tag is there but the metadata does not reflect it.